### PR TITLE
Remove some inefficient regexps

### DIFF
--- a/gosh/main.go
+++ b/gosh/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -381,8 +380,7 @@ func (g *Gosh) setEditor() {
 			g.editor = editor
 			return
 		}
-		re := regexp.MustCompile(`\s+`)
-		parts := re.Split(editor, -1)
+		parts := strings.Fields(editor)
 		if parts[0] == editor {
 			g.addError("bad editor",
 				fmt.Errorf("Cannot find %s (source: %s): %w",

--- a/gosh/shebang.go
+++ b/gosh/shebang.go
@@ -1,8 +1,8 @@
 package main
 
 import (
+	"bytes"
 	"os"
-	"regexp"
 )
 
 // shebangFileContents this will read the contents of the file removing any
@@ -13,8 +13,16 @@ func shebangFileContents(fileName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	re := regexp.MustCompile("^#![^\n]*(\n|$)")
-	content = re.ReplaceAll(content, []byte{})
 
-	return string(content), nil
+	return string(shebangRemove(content)), nil
+}
+
+func shebangRemove(content []byte) []byte {
+	if !bytes.HasPrefix(content, []byte("#!")) {
+		return content
+	}
+	if i := bytes.IndexByte(content, '\n'); i > 1 {
+		return content[i+1:]
+	}
+	return content[:0]
 }

--- a/gosh/shebang_test.go
+++ b/gosh/shebang_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+)
+
+func BenchmarkShebangRx(b *testing.B) {
+	re := regexp.MustCompile("^#![^\n]*(\n|$)")
+	inWants := mkBytes(shebangTests)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, inWant := range inWants {
+			got := re.ReplaceAll(inWant[0], nil)
+			if !bytes.Equal(got, inWant[1]) {
+				b.Fatalf("%q: got %q, wanted %q", string(inWant[0]), string(got), string(inWant[1]))
+			}
+		}
+	}
+}
+func BenchmarkShebangRxEach(b *testing.B) {
+	inWants := mkBytes(shebangTests)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, inWant := range inWants {
+			re := regexp.MustCompile("^#![^\n]*(\n|$)")
+			got := re.ReplaceAll(inWant[0], nil)
+			if !bytes.Equal(got, inWant[1]) {
+				b.Fatalf("%q: got %q, wanted %q", string(inWant[0]), string(got), string(inWant[1]))
+			}
+		}
+	}
+}
+func BenchmarkShebangBytes(b *testing.B) {
+	inWants := mkBytes(shebangTests)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, inWant := range inWants {
+			got := shebangRemove(inWant[0])
+			if !bytes.Equal(got, inWant[1]) {
+				b.Fatalf("%q: got %q, wanted %q", string(inWant[0]), string(got), string(inWant[1]))
+			}
+		}
+	}
+}
+func mkBytes(m map[string]string) [][2][]byte {
+	arr := make([][2][]byte, 0, len(m))
+	for k, v := range m {
+		arr = append(arr, [2][]byte{[]byte(k), []byte(v)})
+	}
+	return arr
+}
+
+func TestShebangBytes(t *testing.T) {
+	for in, want := range shebangTests {
+		got := string(shebangRemove([]byte(in)))
+		if got != want {
+			t.Errorf("%q: got %q, wanted %q", in, got, want)
+		}
+	}
+}
+
+var shebangTests = map[string]string{
+	"#!":             "",
+	"#!\n":           "",
+	"#asd!\r\n":      "#asd!\r\n",
+	"#!/asdsad\nyes": "yes",
+	" #!\n":          " #!\n",
+}


### PR DESCRIPTION
Compiling a regexp is heavy, so it should be done at initialization time, or at least outside of loops.

Sometimes it is not even necessary: trimming the shebang line is simpler with bytes.Index, and splitting around whitespace has its own function: strings.Fields.